### PR TITLE
Pass error down to the webhook handler when webhook fails

### DIFF
--- a/lib/eventbrite/entities/event/get/index.js
+++ b/lib/eventbrite/entities/event/get/index.js
@@ -15,6 +15,7 @@ module.exports = function () {
       json: true},
       function (err, res, body) {
         if (err) return cb(err);
+        if (body.status_code >= 400) return cb(new Error(body.error)); 
         return cb(null, body);
       });
   };


### PR DESCRIPTION
Alas, "request" doesn't return an error on http != 200