### PR TITLE
Add unimplemented handler to avoid falsy error message in hapijs

### DIFF
--- a/lib/eventbrite/controllers/webhook/handlers/index.js
+++ b/lib/eventbrite/controllers/webhook/handlers/index.js
@@ -11,6 +11,8 @@ module.exports = function () {
     var payload = args.config;
     var apiUrl = args.api_url;
     var webhookHandlers = {
+      'event.published': 'unimplementHandler',
+      'attendee.updated': 'unimplementHandler',
       'event.updated': 'eventHandler'
     };
     var act = webhookHandlers[payload.action];

--- a/lib/eventbrite/controllers/webhook/index.js
+++ b/lib/eventbrite/controllers/webhook/index.js
@@ -23,6 +23,10 @@ module.exports = function () {
       eventHandler: {
         validation: require('./eventHandler/validation')(definition),
         cb: require('./eventHandler').bind(this)()
+      },
+      unimplementHandler: {
+        validation: require('./unimplementedHandler/validation')(definition),
+        cb: require('./unimplementedHandler').bind(this)()
       }
     }
   };

--- a/lib/eventbrite/controllers/webhook/unimplementedHandler/index.js
+++ b/lib/eventbrite/controllers/webhook/unimplementedHandler/index.js
@@ -1,0 +1,15 @@
+'use strict';
+var _ = require('lodash');
+var countries = require('country-list')();
+var Promise = require('bluebird');
+var moment = require('moment');
+/**
+ * Webhook handler for any event registred by our webhook but not handled
+ * It should reduce a certain number of unnecesary logs from zen-api
+ * @return {Object}  http code result (200)
+ */
+module.exports = function () {
+  return function (args, done) {
+    return done(null, { http$: { status: 200 } });
+  };
+};

--- a/lib/eventbrite/controllers/webhook/unimplementedHandler/index.spec.js
+++ b/lib/eventbrite/controllers/webhook/unimplementedHandler/index.spec.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var lab = exports.lab = require('lab').script();
+var chai = require('chai');
+var expect = chai.expect;
+chai.use(require('sinon-chai'));
+var sinon = require('sinon');
+var fn = require('./index.js');
+
+lab.experiment('webhook/unimplementHandler', function () {
+  var senecaStub;
+  var handler;
+  var dojo = {
+    id: 1000,
+    eventbriteToken: 'access_token'
+  };
+  lab.beforeEach(function (done) {
+    handler = fn().bind(senecaStub);
+    done();
+  });
+
+  lab.test('should return 200', function (done) {
+    // ACT
+    handler({ dojo: dojo }, function (err, ret) {
+      expect(ret).to.be.eql({ http$: { status: 200 } });
+      done();
+    });
+  });
+});

--- a/lib/eventbrite/controllers/webhook/unimplementedHandler/perm.js
+++ b/lib/eventbrite/controllers/webhook/unimplementedHandler/perm.js
@@ -1,0 +1,5 @@
+module.exports = {
+  'eventHandler': {
+    role: 'none'
+  }
+};

--- a/lib/eventbrite/controllers/webhook/unimplementedHandler/validation.js
+++ b/lib/eventbrite/controllers/webhook/unimplementedHandler/validation.js
@@ -1,0 +1,5 @@
+var Joi = require('joi');
+var _ = require('lodash');
+module.exports = function (definition) {
+  return {};
+};


### PR DESCRIPTION
It basically does nothing, but avoid 401 for "expected but not implemetend" webhooks.
That should make our logging on zen-api less crowded.