### PR TITLE
Return a 403 when the webhook is not authorized to be created

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,21 @@
 /* eslint-disable no-console */
 const newrelic = process.env.NEW_RELIC_ENABLED === 'true' ? require('newrelic') : undefined;
 const senecaNewRelic = require('seneca-newrelic');
-const service = 'cp-eventbrite-service';
 const config = require('./config/config.js')();
 const seneca = require('./imports')(config);
 const util = require('util');
 const { isUndefined } = require('lodash');
 
+const service = 'cp-eventbrite-service';
 if (!isUndefined(newrelic)) {
   seneca.use(senecaNewRelic, {
     newrelic,
     roles: ['cd-eventbrite'],
-    filter (p) {
+    filter(p) {
       p.user = p.user ? p.user.id : undefined;
       p.login = p.login ? p.login.id : undefined;
       return p;
-    }
+    },
   });
 }
 

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -47,11 +47,12 @@ module.exports = () =>
           .createHash('sha256')
           .update(dojoId + token + hashKey)
           .digest('hex');
-        //  TODO: check env prod if contains protocol
         const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
         webhooks
           .create({ actions, token, endpoint_url: endpointUrl })
           .then((webhook) => {
+            // workaround for https://github.com/senecajs/seneca-transport/issues/154
+            if (webhook.http$) return cb(null, webhook);
             seneca.act({
               role: 'cd-dojos',
               entity: 'dojo',

--- a/lib/eventbrite/controllers/auth/authorize/index.spec.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.spec.js
@@ -26,6 +26,9 @@ lab.experiment('Auth/authorize', () => {
     senecaStub = {
       act: sandbox.stub(),
       export: sandbox.stub(),
+      log: {
+        error: sandbox.stub(),
+      },
     };
     exportMock = {
       auth: {
@@ -91,6 +94,26 @@ lab.experiment('Auth/authorize', () => {
     authorize({ dojoId, code, user: { id: 1 } }, (err, ret) => {
       expect(ret).to.be.eql({ ok: true });
       expect(senecaStub.act).to.have.been.calledTwice;
+      expect(senecaStub.export).to.have.been.calledTwice;
+      expect(exportMock.auth.get).to.have.been.calledOnce;
+      expect(exportMock.webhook.create).to.have.been.calledOnce;
+      done();
+    });
+  });
+
+  lab.test('should return an http$ transport response if it\'s provided', (done) => {
+    const dojoLoadMock = {
+      id: dojoId,
+    };
+    senecaStub.act
+      .withArgs({ role: 'cd-dojos', entity: 'dojo', cmd: 'load', id: dojoId })
+      .callsFake((args, cb) => {
+        cb(null, dojoLoadMock);
+      });
+    exportMock.webhook.create = sinon.stub().callsFake(() => Promise.resolve({ http$: { status: 403 }, data: '' }));
+    authorize({ dojoId, code, user: { id: 1 } }, (err, ret) => {
+      expect(ret).to.be.eql({ http$: { status: 403 }, data: '' });
+      expect(senecaStub.act).to.have.been.calledOnce;
       expect(senecaStub.export).to.have.been.calledTwice;
       expect(exportMock.auth.get).to.have.been.calledOnce;
       expect(exportMock.webhook.create).to.have.been.calledOnce;

--- a/lib/eventbrite/entities/webhook/create/index.js
+++ b/lib/eventbrite/entities/webhook/create/index.js
@@ -17,7 +17,14 @@ module.exports = function create() {
       },
       (err, res, body) => {
         if (err) return cb(err);
-        return cb(null, body);
+        if (res.statusCode === 200) {
+          cb(null, body);
+        } else {
+          if (res.statusCode === 403) {
+            return cb(null, { http$: { status: res.statusCode }, data: res.error });
+          }
+          return cb(body);
+        }
       },
     );
   };

--- a/newrelic.js
+++ b/newrelic.js
@@ -9,7 +9,7 @@ exports.config = {
   agent_enabled: false, // set via NEW_RELIC_ENABLED for production
   license_key: '', // set via NEW_RELIC_LICENSE_KEY
   transaction_tracer: {
-    record_sql: 'obfuscated'
+    record_sql: 'obfuscated',
   },
   logging: {
     /**


### PR DESCRIPTION
Hapijs will handle that as a 403 : seneca-web doesn't allow us to respond with 403 :]]]]]]