### PR TITLE
Update API endpoint with Organization ID

### DIFF
--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -4,109 +4,73 @@ const crypto = require('crypto');
 module.exports = () =>
   function authorize(args, cb) {
     const seneca = this;
-    const secKey = process.env.EVENTBRITE_SECRET_KEY;
-    const pubKey = process.env.EVENTBRITE_PUBLIC_KEY;
     const hashKey = process.env.EVENTBRITE_HASH_KEY;
     const hostname = process.env.HOSTNAME;
     const code = args.code;
     const dojoId = args.dojoId;
+    const orgId = args.orgId;
     const user = args.user;
-    const auth = seneca.export('cd-eventbrite/acts').auth;
+    const token = args.userToken;
+    const actions = 'event.published,event.updated,attendee.updated';
+    const webhooks = seneca.export('cd-eventbrite/acts').webhook;
 
-    auth.get({ pubKey, secKey, code }).then((body) => {
-      const token = body.access_token;
-      const actions = 'event.published,event.updated,attendee.updated';
-      const webhooks = seneca.export('cd-eventbrite/acts').webhook;
-      let orgId = '';
-      console.log('YOYO');
-      getOrganisationId().then((res) => {
-        orgId = res;
-
-        //  If there is an existing sync, we remove the previous webhook
-        async.series([removeWebhookIfExists, createNewWebhook], () => {
-          cb(null, { ok: true });
-        });
-      });
-
-      //  If there is an existing sync, we remove the previous webhook
-      // async.series([removeWebhookIfExists, createNewWebhook], () => {
-      //   cb(null, { ok: true });
-      // });
-      function removeWebhookIfExists(sCb) {
-        seneca.act({ role: 'cd-dojos', entity: 'dojo', cmd: 'load', id: dojoId }, (err, dojo) => {
-          if (err) return cb(err);
-          if (dojo.eventbriteToken && dojo.eventbriteWhId) {
-            webhooks
-              .delete({ id: dojo.eventbriteWhId, token })
-              .then(() => {
-                sCb();
-              })
-              /*
-               * We don't save again as it'll normally be saved afterwards
-               * when creating the new webhook
-               */
-              .catch(() => {
-                cb(new Error('Error when deleting existing webhook'));
-              });
-          } else {
-            sCb();
-          }
-        });
-      }
-      function createNewWebhook(sCb) {
-        //  Save eventbrite ids
-        console.log('When does this happen?');
-        const identifier = crypto
-          .createHash('sha256')
-          .update(dojoId + token + hashKey)
-          .digest('hex');
-        const endpointUrl = `https://smee.io/WHGx6yjUMfCAz4Xl`;
-        // const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
-        webhooks
-          .create({ actions, token, endpoint_url: endpointUrl, orgId })
-          .then((webhook) => {
-            // workaround for https://github.com/senecajs/seneca-transport/issues/154
-            if (webhook.http$) return cb(null, webhook);
-            seneca.act({
-              role: 'cd-dojos',
-              entity: 'dojo',
-              cmd: 'update',
-              dojo: {
-                id: dojoId,
-                eventbrite_token: token,
-                eventbrite_wh_id: webhook.id,
-              },
-              user
-            }, (err) => {
-              if (err) return cb(err);
-              sCb();
-            });
-          })
-          .catch((err) => {
-            seneca.log.error(err);
-            return cb(new Error('An unknown error happened'));
-          });
-      };
-      async function getOrganisationId() {
-        console.log('THIS HAPPENS NOW');
-        let orgId = '';
-        await webhooks
-          .get({token})
-          .then((res) => {
-            // orgId = res['organizations'][0]['id'];
-            if (res['organizations'].length === 1) {
-              orgId = res['organizations'][0]['id'];
-            } else {
-              orgId = res['organizations'];
-              console.log('*****',res['organizations']);
-              console.log('length', res['organizations'].length);
-            }
-          })
-          .catch((err) => {
-            seneca.log.error(err);
-            return cb(new Error('An unknown error happened'));
-          });
-        return orgId;
-      };
+    //  If there is an existing sync, we remove the previous webhook
+    async.series([removeWebhookIfExists, createNewWebhook], () => {
+      cb(null, { ok: true });
     });
+
+    function removeWebhookIfExists(sCb) {
+      seneca.act({ role: 'cd-dojos', entity: 'dojo', cmd: 'load', id: dojoId }, (err, dojo) => {
+        if (err) return cb(err);
+        if (dojo.eventbriteToken && dojo.eventbriteWhId) {
+          webhooks
+            .delete({ id: dojo.eventbriteWhId, token })
+            .then(() => {
+              sCb();
+            })
+            /*
+              * We don't save again as it'll normally be saved afterwards
+              * when creating the new webhook
+              */
+            .catch(() => {
+              cb(new Error('Error when deleting existing webhook'));
+            });
+        } else {
+          sCb();
+        }
+      });
+    }
+    function createNewWebhook(sCb) {
+      //  Save eventbrite ids
+      const identifier = crypto
+        .createHash('sha256')
+        .update(dojoId + token + hashKey)
+        .digest('hex');
+      const endpointUrl = `https://smee.io/WHGx6yjUMfCAz4Xl`;
+      // const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
+      webhooks
+        .create({ actions, token, endpoint_url: endpointUrl, orgId })
+        .then((webhook) => {
+          // workaround for https://github.com/senecajs/seneca-transport/issues/154
+          if (webhook.http$) return cb(null, webhook);
+          seneca.act({
+            role: 'cd-dojos',
+            entity: 'dojo',
+            cmd: 'update',
+            dojo: {
+              id: dojoId,
+              eventbrite_token: token,
+              eventbrite_wh_id: webhook.id,
+            },
+            user
+          }, (err) => {
+            if (err) return cb(err);
+            sCb();
+          });
+        })
+        .catch((err) => {
+          seneca.log.error(err);
+          return cb(new Error('An unknown error happened'));
+        });
+    };
   };

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -46,8 +46,8 @@ module.exports = () =>
         .createHash('sha256')
         .update(dojoId + token + hashKey)
         .digest('hex');
-      const endpointUrl = `https://smee.io/WHGx6yjUMfCAz4Xl`;
-      // const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
+      // const endpointUrl = `https://smee.io/WHGx6yjUMfCAz4Xl`;
+      const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
       webhooks
         .create({ actions, token, endpoint_url: endpointUrl, orgId })
         .then((webhook) => {

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -12,18 +12,25 @@ module.exports = () =>
     const dojoId = args.dojoId;
     const user = args.user;
     const auth = seneca.export('cd-eventbrite/acts').auth;
+
     auth.get({ pubKey, secKey, code }).then((body) => {
       const token = body.access_token;
-      // console.log('TOKEN', token);
-      // console.log('BODY', body);
       const actions = 'event.published,event.updated,attendee.updated';
       const webhooks = seneca.export('cd-eventbrite/acts').webhook;
-      //  If there is an existing sync, we remove the previous webhook
-      const organisationId = getOrganisationId();
-      // console.log(organisationId);
-      async.series([removeWebhookIfExists, createNewWebhook], () => {
-        cb(null, { ok: true });
+
+      getOrganisationId().then((value) => {
+        console.log('inside',value);
+
+        //  If there is an existing sync, we remove the previous webhook
+        async.series([removeWebhookIfExists, createNewWebhook], () => {
+          cb(null, { ok: true });
+        });
       });
+
+      //  If there is an existing sync, we remove the previous webhook
+      // async.series([removeWebhookIfExists, createNewWebhook], () => {
+      //   cb(null, { ok: true });
+      // });
       function removeWebhookIfExists(sCb) {
         seneca.act({ role: 'cd-dojos', entity: 'dojo', cmd: 'load', id: dojoId }, (err, dojo) => {
           if (err) return cb(err);
@@ -47,6 +54,7 @@ module.exports = () =>
       }
       function createNewWebhook(sCb) {
         //  Save eventbrite ids
+        console.log('IN WEBHOOK');
         const identifier = crypto
           .createHash('sha256')
           .update(dojoId + token + hashKey)
@@ -78,17 +86,18 @@ module.exports = () =>
             return cb(new Error('An unknown error happened'));
           });
       };
-      function getOrganisationId() {
-        console.log('this being hit?');
-        webhooks
+      async function getOrganisationId() {
+        let orgId = '';
+        await webhooks
           .get({token})
           .then((response) => {
-            console.log(response)
+            orgId = response['organizations'][0]['id'];
           })
           .catch((err) => {
             seneca.log.error(err);
             return cb(new Error('An unknown error happened'));
           });
+        return orgId;
       };
     });
   };

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -70,7 +70,7 @@ module.exports = () =>
         })
         .catch((err) => {
           seneca.log.error(err);
-          return cb(new Error('An unknown error happened'));
+          return cb(new Error('Error when creating new webhook'));
         });
     };
   };

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -46,7 +46,6 @@ module.exports = () =>
         .createHash('sha256')
         .update(dojoId + token + hashKey)
         .digest('hex');
-      // const endpointUrl = `https://smee.io/WHGx6yjUMfCAz4Xl`;
       const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
       webhooks
         .create({ actions, token, endpoint_url: endpointUrl, orgId })

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -14,9 +14,13 @@ module.exports = () =>
     const auth = seneca.export('cd-eventbrite/acts').auth;
     auth.get({ pubKey, secKey, code }).then((body) => {
       const token = body.access_token;
+      // console.log('TOKEN', token);
+      // console.log('BODY', body);
       const actions = 'event.published,event.updated,attendee.updated';
       const webhooks = seneca.export('cd-eventbrite/acts').webhook;
       //  If there is an existing sync, we remove the previous webhook
+      const organisationId = getOrganisationId();
+      // console.log(organisationId);
       async.series([removeWebhookIfExists, createNewWebhook], () => {
         cb(null, { ok: true });
       });
@@ -47,7 +51,8 @@ module.exports = () =>
           .createHash('sha256')
           .update(dojoId + token + hashKey)
           .digest('hex');
-        const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
+        const endpointUrl = `https://smee.io/WHGx6yjUMfCAz4Xl`;
+        // const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
         webhooks
           .create({ actions, token, endpoint_url: endpointUrl })
           .then((webhook) => {
@@ -72,6 +77,18 @@ module.exports = () =>
             seneca.log.error(err);
             return cb(new Error('An unknown error happened'));
           });
-      }
+      };
+      function getOrganisationId() {
+        console.log('this being hit?');
+        webhooks
+          .get({token})
+          .then((response) => {
+            console.log(response)
+          })
+          .catch((err) => {
+            seneca.log.error(err);
+            return cb(new Error('An unknown error happened'));
+          });
+      };
     });
   };

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -17,9 +17,10 @@ module.exports = () =>
       const token = body.access_token;
       const actions = 'event.published,event.updated,attendee.updated';
       const webhooks = seneca.export('cd-eventbrite/acts').webhook;
+      let orgId = '';
 
-      getOrganisationId().then((value) => {
-        console.log('inside',value);
+      getOrganisationId().then((res) => {
+        orgId = res;
 
         //  If there is an existing sync, we remove the previous webhook
         async.series([removeWebhookIfExists, createNewWebhook], () => {
@@ -54,7 +55,6 @@ module.exports = () =>
       }
       function createNewWebhook(sCb) {
         //  Save eventbrite ids
-        console.log('IN WEBHOOK');
         const identifier = crypto
           .createHash('sha256')
           .update(dojoId + token + hashKey)
@@ -62,7 +62,7 @@ module.exports = () =>
         const endpointUrl = `https://smee.io/WHGx6yjUMfCAz4Xl`;
         // const endpointUrl = `https://${hostname}/api/2.0/eventbrite/webhooks/${identifier}`;
         webhooks
-          .create({ actions, token, endpoint_url: endpointUrl })
+          .create({ actions, token, endpoint_url: endpointUrl, orgId })
           .then((webhook) => {
             // workaround for https://github.com/senecajs/seneca-transport/issues/154
             if (webhook.http$) return cb(null, webhook);

--- a/lib/eventbrite/controllers/auth/authorize/index.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.js
@@ -18,7 +18,7 @@ module.exports = () =>
       const actions = 'event.published,event.updated,attendee.updated';
       const webhooks = seneca.export('cd-eventbrite/acts').webhook;
       let orgId = '';
-
+      console.log('YOYO');
       getOrganisationId().then((res) => {
         orgId = res;
 
@@ -55,6 +55,7 @@ module.exports = () =>
       }
       function createNewWebhook(sCb) {
         //  Save eventbrite ids
+        console.log('When does this happen?');
         const identifier = crypto
           .createHash('sha256')
           .update(dojoId + token + hashKey)
@@ -75,7 +76,7 @@ module.exports = () =>
                 eventbrite_token: token,
                 eventbrite_wh_id: webhook.id,
               },
-              user,
+              user
             }, (err) => {
               if (err) return cb(err);
               sCb();
@@ -87,11 +88,19 @@ module.exports = () =>
           });
       };
       async function getOrganisationId() {
+        console.log('THIS HAPPENS NOW');
         let orgId = '';
         await webhooks
           .get({token})
-          .then((response) => {
-            orgId = response['organizations'][0]['id'];
+          .then((res) => {
+            // orgId = res['organizations'][0]['id'];
+            if (res['organizations'].length === 1) {
+              orgId = res['organizations'][0]['id'];
+            } else {
+              orgId = res['organizations'];
+              console.log('*****',res['organizations']);
+              console.log('length', res['organizations'].length);
+            }
           })
           .catch((err) => {
             seneca.log.error(err);

--- a/lib/eventbrite/controllers/auth/authorize/index.spec.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.spec.js
@@ -70,7 +70,6 @@ lab.experiment('Auth/authorize', () => {
       eventbrite_token: userToken,
       eventbrite_wh_id: 42,
     };
-
     senecaStub.act
       .withArgs({ role: 'cd-dojos', entity: 'dojo', cmd: 'load', id: dojoId })
       .callsFake((args, cb) => {
@@ -87,11 +86,13 @@ lab.experiment('Auth/authorize', () => {
       .callsFake((args, cb) => {
         cb(null, { id: dojoId });
       });
-    authorize({ dojoId, code, user: { id: 1 } }, (err, ret) => {
+    console.log('YOYO');
+    authorize({ dojoId, orgId, code, userToken, user: { id: 1 } }, (err, ret) => {
+      console.log('ARGS', dojoId, orgId, code, userToken);
+      console.log('RESPONSE', ret);
       expect(ret).to.be.eql({ ok: true });
       expect(senecaStub.act).to.have.been.calledTwice;
       expect(senecaStub.export).to.have.been.calledTwice;
-      // expect(exportMock.auth.get).to.have.been.calledOnce;
       expect(exportMock.webhook.create).to.have.been.calledOnce;
       done();
     });
@@ -107,7 +108,7 @@ lab.experiment('Auth/authorize', () => {
         cb(null, dojoLoadMock);
       });
     exportMock.webhook.create = sinon.stub().callsFake(() => Promise.resolve({ http$: { status: 403 }, data: '' }));
-    authorize({ dojoId, code, user: { id: 1 } }, (err, ret) => {
+    authorize({ dojoId, orgId, code, userToken, user: { id: 1 } }, (err, ret) => {
       expect(ret).to.be.eql({ http$: { status: 403 }, data: '' });
       expect(senecaStub.act).to.have.been.calledOnce;
       expect(senecaStub.export).to.have.been.calledTwice;
@@ -151,7 +152,7 @@ lab.experiment('Auth/authorize', () => {
         cb(null, { id: dojoId });
       });
     // ACT
-    authorize({ dojoId, code, user: { id: 1 } }, (err, ret) => {
+    authorize({ dojoId, orgId, code, userToken, user: { id: 1 } }, (err, ret) => {
       expect(ret).to.be.eql({ ok: true });
       // expect(exportMock.auth.get).to.have.been.calledOnce;
       expect(senecaStub.export).to.have.been.calledTwice;

--- a/lib/eventbrite/controllers/auth/authorize/index.spec.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.spec.js
@@ -18,9 +18,11 @@ lab.experiment('Auth/authorize', () => {
   let exportMock;
   const dojoId = 1000;
   const code = 'abcdefgh';
+  const userToken = 'D48HKJJ91823';
+  const orgId = 801521497943;
+
   process.env.EVENTBRITE_HASH_KEY = 'hashKey';
-  process.env.EVENTBRITE_PUBLIC_KEY = 'publicKey';
-  process.env.EVENTBRITE_SECRET_KEY = 'secretKey';
+
   lab.beforeEach((done) => {
     sandbox = sinon.sandbox.create();
     senecaStub = {
@@ -31,28 +33,21 @@ lab.experiment('Auth/authorize', () => {
       },
     };
     exportMock = {
-      auth: {
-        get: sandbox.stub().callsFake((args) => {
-          expect(args.pubKey).to.equal(process.env.EVENTBRITE_PUBLIC_KEY);
-          expect(args.secKey).to.equal(process.env.EVENTBRITE_SECRET_KEY);
-          expect(args.code).to.equal(code);
-          return Promise.resolve({
-            access_token: 'access_token',
-          });
-        }),
-      },
       webhook: {
         create: sandbox.stub().callsFake((args) => {
-          expect(args.token).to.equal('access_token');
+          args.token = userToken;
+          args.orgId = orgId;
+
+          expect(args.endpoint_url).to.equal('https://smee.io/WHGx6yjUMfCAz4Xl');
           expect(args.actions).to.equal('event.published,event.updated,attendee.updated');
-          expect(args.endpoint_url).to.equal(
-            'https://localhost.localdomain/api/2.0/eventbrite/webhooks/fe28b4ee994fa96f6a6f4e2829929ed25aa941fa6aab9acfff728f55dc125fe3',
-          );
+          // expect(args.endpoint_url).to.equal(
+          //   'https://localhost.localdomain/api/2.0/eventbrite/webhooks/fe28b4ee994fa96f6a6f4e2829929ed25aa941fa6aab9acfff728f55dc125fe3',
+          // );
           return Promise.resolve({
             id: 42,
           });
         }),
-        delete: sandbox.stub(),
+        delete: sandbox.stub()
       },
     };
     senecaStub.export.withArgs('cd-eventbrite/acts').returns(exportMock);
@@ -72,9 +67,10 @@ lab.experiment('Auth/authorize', () => {
     };
     const dojoSaveMock = {
       id: dojoId,
-      eventbrite_token: 'access_token',
+      eventbrite_token: userToken,
       eventbrite_wh_id: 42,
     };
+
     senecaStub.act
       .withArgs({ role: 'cd-dojos', entity: 'dojo', cmd: 'load', id: dojoId })
       .callsFake((args, cb) => {
@@ -95,7 +91,7 @@ lab.experiment('Auth/authorize', () => {
       expect(ret).to.be.eql({ ok: true });
       expect(senecaStub.act).to.have.been.calledTwice;
       expect(senecaStub.export).to.have.been.calledTwice;
-      expect(exportMock.auth.get).to.have.been.calledOnce;
+      // expect(exportMock.auth.get).to.have.been.calledOnce;
       expect(exportMock.webhook.create).to.have.been.calledOnce;
       done();
     });
@@ -115,7 +111,7 @@ lab.experiment('Auth/authorize', () => {
       expect(ret).to.be.eql({ http$: { status: 403 }, data: '' });
       expect(senecaStub.act).to.have.been.calledOnce;
       expect(senecaStub.export).to.have.been.calledTwice;
-      expect(exportMock.auth.get).to.have.been.calledOnce;
+      // expect(exportMock.auth.get).to.have.been.calledOnce;
       expect(exportMock.webhook.create).to.have.been.calledOnce;
       done();
     });
@@ -125,12 +121,12 @@ lab.experiment('Auth/authorize', () => {
     // ARRANGE
     const dojoLoadMock = {
       id: dojoId,
-      eventbriteToken: 'access_token-1',
+      eventbriteToken: userToken,
       eventbriteWhId: 41,
     };
     const dojoSaveMock = {
       id: dojoId,
-      eventbrite_token: 'access_token',
+      eventbrite_token: userToken,
       eventbrite_wh_id: 42,
     };
     senecaStub.act
@@ -139,9 +135,8 @@ lab.experiment('Auth/authorize', () => {
         cb(null, dojoLoadMock);
       });
     exportMock.webhook.delete.callsFake((args) => {
+      args.token = userToken;
       expect(args.id).to.equal(41);
-      // We use the current access token, not the old one
-      expect(args.token).to.equal('access_token');
       return Promise.resolve();
     });
     senecaStub.act
@@ -158,7 +153,7 @@ lab.experiment('Auth/authorize', () => {
     // ACT
     authorize({ dojoId, code, user: { id: 1 } }, (err, ret) => {
       expect(ret).to.be.eql({ ok: true });
-      expect(exportMock.auth.get).to.have.been.calledOnce;
+      // expect(exportMock.auth.get).to.have.been.calledOnce;
       expect(senecaStub.export).to.have.been.calledTwice;
       expect(senecaStub.act).to.have.been.calledTwice;
       expect(exportMock.webhook.delete).to.have.been.calledOnce;

--- a/lib/eventbrite/controllers/auth/authorize/index.spec.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.spec.js
@@ -35,9 +35,8 @@ lab.experiment('Auth/authorize', () => {
     exportMock = {
       webhook: {
         create: sandbox.stub().callsFake((args) => {
-          // args.token = userToken;
-          // args.orgId = orgId;
-
+          expect(args.token).to.equal(userToken);
+          expect(args.orgId).to.equal(orgId);
           expect(args.endpoint_url).to.equal('https://smee.io/WHGx6yjUMfCAz4Xl');
           expect(args.actions).to.equal('event.published,event.updated,attendee.updated');
           // expect(args.endpoint_url).to.equal(

--- a/lib/eventbrite/controllers/auth/authorize/index.spec.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.spec.js
@@ -37,11 +37,10 @@ lab.experiment('Auth/authorize', () => {
         create: sandbox.stub().callsFake((args) => {
           expect(args.token).to.equal(userToken);
           expect(args.orgId).to.equal(orgId);
-          expect(args.endpoint_url).to.equal('https://smee.io/WHGx6yjUMfCAz4Xl');
           expect(args.actions).to.equal('event.published,event.updated,attendee.updated');
-          // expect(args.endpoint_url).to.equal(
-          //   'https://localhost.localdomain/api/2.0/eventbrite/webhooks/fe28b4ee994fa96f6a6f4e2829929ed25aa941fa6aab9acfff728f55dc125fe3',
-          // );
+          expect(args.endpoint_url).to.equal(
+            'https://localhost.localdomain/api/2.0/eventbrite/webhooks/3146a99b86560bbc3a23e008f89a5670d1df37c77778b2fb785cb7deaa191b0a',
+          );
 
           return Promise.resolve({
             id: 42,

--- a/lib/eventbrite/controllers/auth/authorize/index.spec.js
+++ b/lib/eventbrite/controllers/auth/authorize/index.spec.js
@@ -35,14 +35,15 @@ lab.experiment('Auth/authorize', () => {
     exportMock = {
       webhook: {
         create: sandbox.stub().callsFake((args) => {
-          args.token = userToken;
-          args.orgId = orgId;
+          // args.token = userToken;
+          // args.orgId = orgId;
 
           expect(args.endpoint_url).to.equal('https://smee.io/WHGx6yjUMfCAz4Xl');
           expect(args.actions).to.equal('event.published,event.updated,attendee.updated');
           // expect(args.endpoint_url).to.equal(
           //   'https://localhost.localdomain/api/2.0/eventbrite/webhooks/fe28b4ee994fa96f6a6f4e2829929ed25aa941fa6aab9acfff728f55dc125fe3',
           // );
+
           return Promise.resolve({
             id: 42,
           });
@@ -86,13 +87,10 @@ lab.experiment('Auth/authorize', () => {
       .callsFake((args, cb) => {
         cb(null, { id: dojoId });
       });
-    console.log('YOYO');
     authorize({ dojoId, orgId, code, userToken, user: { id: 1 } }, (err, ret) => {
-      console.log('ARGS', dojoId, orgId, code, userToken);
-      console.log('RESPONSE', ret);
       expect(ret).to.be.eql({ ok: true });
       expect(senecaStub.act).to.have.been.calledTwice;
-      expect(senecaStub.export).to.have.been.calledTwice;
+      expect(senecaStub.export).to.have.been.calledOnce;
       expect(exportMock.webhook.create).to.have.been.calledOnce;
       done();
     });
@@ -111,8 +109,7 @@ lab.experiment('Auth/authorize', () => {
     authorize({ dojoId, orgId, code, userToken, user: { id: 1 } }, (err, ret) => {
       expect(ret).to.be.eql({ http$: { status: 403 }, data: '' });
       expect(senecaStub.act).to.have.been.calledOnce;
-      expect(senecaStub.export).to.have.been.calledTwice;
-      // expect(exportMock.auth.get).to.have.been.calledOnce;
+      expect(senecaStub.export).to.have.been.calledOnce;
       expect(exportMock.webhook.create).to.have.been.calledOnce;
       done();
     });
@@ -136,8 +133,8 @@ lab.experiment('Auth/authorize', () => {
         cb(null, dojoLoadMock);
       });
     exportMock.webhook.delete.callsFake((args) => {
-      args.token = userToken;
       expect(args.id).to.equal(41);
+      expect(args.token).to.equal(userToken);
       return Promise.resolve();
     });
     senecaStub.act
@@ -154,8 +151,7 @@ lab.experiment('Auth/authorize', () => {
     // ACT
     authorize({ dojoId, orgId, code, userToken, user: { id: 1 } }, (err, ret) => {
       expect(ret).to.be.eql({ ok: true });
-      // expect(exportMock.auth.get).to.have.been.calledOnce;
-      expect(senecaStub.export).to.have.been.calledTwice;
+      expect(senecaStub.export).to.have.been.calledOnce;
       expect(senecaStub.act).to.have.been.calledTwice;
       expect(exportMock.webhook.delete).to.have.been.calledOnce;
       expect(exportMock.webhook.create).to.have.been.calledOnce;

--- a/lib/eventbrite/controllers/auth/authorize/validation.js
+++ b/lib/eventbrite/controllers/auth/authorize/validation.js
@@ -3,4 +3,6 @@ const Joi = require('joi');
 module.exports = () => ({
   dojoId: Joi.string().guid().required(),
   code: Joi.string().required(),
+  userToken: Joi.string().required(),
+  orgId: Joi.string().required(),
 });

--- a/lib/eventbrite/controllers/auth/get/index.js
+++ b/lib/eventbrite/controllers/auth/get/index.js
@@ -14,18 +14,22 @@ module.exports = () =>
       const webhooks = seneca.export('cd-eventbrite/acts').webhook;
 
       getOrganisationId().then((res) => {
-        response.orgId = res;
+        response.organisations = res;
         response.token = token;
         return cb(null, response);
       });
 
       async function getOrganisationId() {
-        let orgId = '';
+        // let orgId = '';
+        let organisations = [];
 
         await webhooks
           .get({token})
           .then((res) => {
-            orgId = res['organizations'][0]['id'];
+            res['organizations'].forEach(org => {
+              organisations.push({'name' : org.name, 'id' : org.id});
+            });
+            // orgId = res['organizations'][0]['id'];
             // if (res['organizations'].length === 1) {
             //   orgId = res['organizations'][0]['id'];
             // } else {
@@ -39,7 +43,8 @@ module.exports = () =>
             return cb(new Error('An unknown error happened'));
           });
 
-        return orgId;
+        return organisations;
+        // return orgId;
       }
     });
   };

--- a/lib/eventbrite/controllers/auth/get/index.js
+++ b/lib/eventbrite/controllers/auth/get/index.js
@@ -17,6 +17,10 @@ module.exports = () =>
         response.organisations = res;
         response.token = token;
         return cb(null, response);
+      })
+      .catch((err) => {
+        seneca.log.error(err);
+        return cb(new Error('An unknown error happened'));
       });
 
       async function getOrganisationId() {
@@ -31,7 +35,7 @@ module.exports = () =>
           })
           .catch((err) => {
             seneca.log.error(err);
-            return cb(new Error('An unknown error happened'));
+            return cb(new Error('Error when getting organisations'));
           });
 
         return organisations;

--- a/lib/eventbrite/controllers/auth/get/index.js
+++ b/lib/eventbrite/controllers/auth/get/index.js
@@ -23,21 +23,21 @@ module.exports = () =>
         let orgId = '';
 
         await webhooks
-        .get({token})
-        .then((res) => {
-          orgId = res['organizations'][0]['id'];
-          // if (res['organizations'].length === 1) {
-          //   orgId = res['organizations'][0]['id'];
-          // } else {
-          //   orgId = res['organizations'];
-          //   console.log('*****',res['organizations']);
-          //   console.log('length', res['organizations'].length);
-          // }
-        })
-        .catch((err) => {
-          seneca.log.error(err);
-          return cb(new Error('An unknown error happened'));
-        });
+          .get({token})
+          .then((res) => {
+            orgId = res['organizations'][0]['id'];
+            // if (res['organizations'].length === 1) {
+            //   orgId = res['organizations'][0]['id'];
+            // } else {
+            //   orgId = res['organizations'];
+            //   console.log('*****',res['organizations']);
+            //   console.log('length', res['organizations'].length);
+            // }
+          })
+          .catch((err) => {
+            seneca.log.error(err);
+            return cb(new Error('An unknown error happened'));
+          });
 
         return orgId;
       }

--- a/lib/eventbrite/controllers/auth/get/index.js
+++ b/lib/eventbrite/controllers/auth/get/index.js
@@ -1,62 +1,45 @@
-const request = require('request');
-
-// module.exports = () => {
-//   function getOrganisations(args, cb) {
-//     console.log('Just checking this is hitting here ORGS ID')
-//     console.log('THIS IS THE ARGS',args);
-//     console.log('*******');
-//   };
-// request
-//   .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${args.token}`)
-//   .on('response', (res) => {
-//     if (res.statusCode === 200) {
-//       res.on('data', (chunk) => {
-//         const body = JSON.parse(chunk);
-//         cb(null, body);
-//       });
-//     } else {
-//       cb('Invalid payload while authenticating to Eventbrite');
-//     }
-//   })
-//   .on('error', (err) => {
-//     console.log('ERROR');
-//     cb(err);
-//   });
-// };
-
+const async = require('async');
 
 module.exports = () =>
   function getOrganisations(args, cb) {
-    console.log('Just checking this is hitting here ORGS ID');
-    console.log('THIS IS THE ARGS', args);
-
     const seneca = this;
     const secKey = process.env.EVENTBRITE_SECRET_KEY;
     const pubKey = process.env.EVENTBRITE_PUBLIC_KEY;
     const code = args.code;
-    const user = args.user;
     const auth = seneca.export('cd-eventbrite/acts').auth;
+    const response = {};
 
     auth.get({ pubKey, secKey, code }).then((body) => {
       const token = body.access_token;
+      const webhooks = seneca.export('cd-eventbrite/acts').webhook;
 
-      request
-        .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${token}`)
-        .on('response', (res) => {
-          if (res.statusCode === 200) {
-            res.on('data', (chunk) => {
-              const body = JSON.parse(chunk);
-              console.log('BODY RESPONSE', body)
-              cb(null, body);
-            });
-          } else {
-            cb('Invalid payload while authenticating to Eventbrite');
-          }
+      getOrganisationId().then((res) => {
+        response.orgId = res;
+        response.token = token;
+        return cb(null, response);
+      });
+
+      async function getOrganisationId() {
+        let orgId = '';
+
+        await webhooks
+        .get({token})
+        .then((res) => {
+          orgId = res['organizations'][0]['id'];
+          // if (res['organizations'].length === 1) {
+          //   orgId = res['organizations'][0]['id'];
+          // } else {
+          //   orgId = res['organizations'];
+          //   console.log('*****',res['organizations']);
+          //   console.log('length', res['organizations'].length);
+          // }
         })
-        .on('error', (err) => {
-          console.log('ERROR', err);
-          cb(err);
+        .catch((err) => {
+          seneca.log.error(err);
+          return cb(new Error('An unknown error happened'));
         });
+
+        return orgId;
+      }
     });
-    console.log('*******************************************');
   };

--- a/lib/eventbrite/controllers/auth/get/index.js
+++ b/lib/eventbrite/controllers/auth/get/index.js
@@ -1,0 +1,23 @@
+const request = require('request');
+
+module.exports = () => (args, cb) => {
+  console.log('Just checking this is hitting here ORGS ID')
+  console.log('THIS IS THE ARGS',args);
+  console.log('*******');
+  request
+    .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${args.token}`)
+    .on('response', (res) => {
+      if (res.statusCode === 200) {
+        res.on('data', (chunk) => {
+          const body = JSON.parse(chunk);
+          cb(null, body);
+        });
+      } else {
+        cb('Invalid payload while authenticating to Eventbrite');
+      }
+    })
+    .on('error', (err) => {
+      console.log('ERROR');
+      cb(err);
+    });
+};

--- a/lib/eventbrite/controllers/auth/get/index.js
+++ b/lib/eventbrite/controllers/auth/get/index.js
@@ -20,7 +20,6 @@ module.exports = () =>
       });
 
       async function getOrganisationId() {
-        // let orgId = '';
         let organisations = [];
 
         await webhooks
@@ -29,14 +28,6 @@ module.exports = () =>
             res['organizations'].forEach(org => {
               organisations.push({'name' : org.name, 'id' : org.id});
             });
-            // orgId = res['organizations'][0]['id'];
-            // if (res['organizations'].length === 1) {
-            //   orgId = res['organizations'][0]['id'];
-            // } else {
-            //   orgId = res['organizations'];
-            //   console.log('*****',res['organizations']);
-            //   console.log('length', res['organizations'].length);
-            // }
           })
           .catch((err) => {
             seneca.log.error(err);
@@ -44,7 +35,6 @@ module.exports = () =>
           });
 
         return organisations;
-        // return orgId;
       }
     });
   };

--- a/lib/eventbrite/controllers/auth/get/index.js
+++ b/lib/eventbrite/controllers/auth/get/index.js
@@ -1,23 +1,62 @@
 const request = require('request');
 
-module.exports = () => (args, cb) => {
-  console.log('Just checking this is hitting here ORGS ID')
-  console.log('THIS IS THE ARGS',args);
-  console.log('*******');
-  request
-    .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${args.token}`)
-    .on('response', (res) => {
-      if (res.statusCode === 200) {
-        res.on('data', (chunk) => {
-          const body = JSON.parse(chunk);
-          cb(null, body);
+// module.exports = () => {
+//   function getOrganisations(args, cb) {
+//     console.log('Just checking this is hitting here ORGS ID')
+//     console.log('THIS IS THE ARGS',args);
+//     console.log('*******');
+//   };
+// request
+//   .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${args.token}`)
+//   .on('response', (res) => {
+//     if (res.statusCode === 200) {
+//       res.on('data', (chunk) => {
+//         const body = JSON.parse(chunk);
+//         cb(null, body);
+//       });
+//     } else {
+//       cb('Invalid payload while authenticating to Eventbrite');
+//     }
+//   })
+//   .on('error', (err) => {
+//     console.log('ERROR');
+//     cb(err);
+//   });
+// };
+
+
+module.exports = () =>
+  function getOrganisations(args, cb) {
+    console.log('Just checking this is hitting here ORGS ID');
+    console.log('THIS IS THE ARGS', args);
+
+    const seneca = this;
+    const secKey = process.env.EVENTBRITE_SECRET_KEY;
+    const pubKey = process.env.EVENTBRITE_PUBLIC_KEY;
+    const code = args.code;
+    const user = args.user;
+    const auth = seneca.export('cd-eventbrite/acts').auth;
+
+    auth.get({ pubKey, secKey, code }).then((body) => {
+      const token = body.access_token;
+
+      request
+        .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${token}`)
+        .on('response', (res) => {
+          if (res.statusCode === 200) {
+            res.on('data', (chunk) => {
+              const body = JSON.parse(chunk);
+              console.log('BODY RESPONSE', body)
+              cb(null, body);
+            });
+          } else {
+            cb('Invalid payload while authenticating to Eventbrite');
+          }
+        })
+        .on('error', (err) => {
+          console.log('ERROR', err);
+          cb(err);
         });
-      } else {
-        cb('Invalid payload while authenticating to Eventbrite');
-      }
-    })
-    .on('error', (err) => {
-      console.log('ERROR');
-      cb(err);
     });
-};
+    console.log('*******************************************');
+  };

--- a/lib/eventbrite/controllers/auth/get/index.spec.js
+++ b/lib/eventbrite/controllers/auth/get/index.spec.js
@@ -1,0 +1,78 @@
+exports.lab = require('lab').script();
+
+const lab = exports.lab;
+const chai = require('chai');
+
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+const sinon = require('sinon');
+const fn = require('./index');
+const Promise = require('bluebird');
+
+lab.experiment('Auth/get', () => {
+  let sandbox;
+  let senecaStub;
+  let exportMock;
+  let getOrganisations;
+  const code = 'abcdefgh';
+
+  lab.beforeEach((done) => {
+    sandbox = sinon.sandbox.create();
+    senecaStub = {
+      export: sandbox.stub(),
+      log: {
+        error: sandbox.stub(),
+      },
+    };
+    exportMock = {
+      auth: {
+        get: sandbox.stub().callsFake((args) => {
+          expect(args.pubKey).to.equal(process.env.EVENTBRITE_PUBLIC_KEY);
+          expect(args.secKey).to.equal(process.env.EVENTBRITE_SECRET_KEY);
+          expect(args.code).to.equal(code);
+          return Promise.resolve({
+            access_token: 'access_token',
+          });
+        }),
+      },
+      webhook: {
+        get: sandbox.stub().callsFake((args) => {
+          expect(args.token).to.equal('access_token');
+          return Promise.resolve({
+            organizations:
+              [{ _type: 'organization',
+                name: 'Raspberry Dojo',
+                vertical: 'default',
+                parent_id: null,
+                locale: 'en_SG',
+                image_id: null,
+                id: '801521497943' }]
+          });
+        }),
+      },
+    };
+    senecaStub.export.withArgs('cd-eventbrite/acts').returns(exportMock);
+    getOrganisations = fn().bind(senecaStub);
+    done();
+  });
+
+  lab.afterEach((done) => {
+    sandbox.restore();
+    done();
+  });
+
+  lab.test('should get a list of organisations', (done) => {
+    process.env.EVENTBRITE_PUBLIC_KEY = 'publicKey';
+    process.env.EVENTBRITE_SECRET_KEY = 'secretKey';
+
+    getOrganisations({code}, (err, res) => {
+      expect(err).to.not.exist;
+      expect(res.organisations[0].name).to.equal('Raspberry Dojo');
+      expect(res.organisations[0].id).to.equal('801521497943');
+      expect(res.token).to.equal('access_token');
+      expect(exportMock.auth.get).to.have.been.calledOnce;
+      expect(exportMock.webhook.get).to.have.been.calledOnce;
+      done();
+    });
+  });
+});

--- a/lib/eventbrite/controllers/auth/get/perm.js
+++ b/lib/eventbrite/controllers/auth/get/perm.js
@@ -1,12 +1,5 @@
 module.exports = {
   getOrganisations: [{
-    role: 'basic-user',
-    customValidator: [
-      {
-        role: 'cd-dojos',
-        cmd: 'have_permissions_on_dojo',
-        perm: 'dojo-admin',
-      },
-    ],
+    role: 'basic-user'
   }],
 };

--- a/lib/eventbrite/controllers/auth/get/perm.js
+++ b/lib/eventbrite/controllers/auth/get/perm.js
@@ -1,5 +1,12 @@
 module.exports = {
   getOrganisations: [{
     role: 'basic-user',
+    customValidator: [
+      {
+        role: 'cd-dojos',
+        cmd: 'have_permissions_on_dojo',
+        perm: 'dojo-admin',
+      },
+    ],
   }],
 };

--- a/lib/eventbrite/controllers/auth/get/perm.js
+++ b/lib/eventbrite/controllers/auth/get/perm.js
@@ -1,0 +1,5 @@
+module.exports = {
+  getOrganisations: [{
+    role: 'basic-user',
+  }],
+};

--- a/lib/eventbrite/controllers/auth/get/validation.js
+++ b/lib/eventbrite/controllers/auth/get/validation.js
@@ -1,9 +1,4 @@
 const Joi = require('joi');
-console.log('VALIDATION');
-
-// module.exports = () => ({
-//   code: Joi.string().required(),
-// });
 
 module.exports = () => ({
   code: Joi.string().required(),

--- a/lib/eventbrite/controllers/auth/get/validation.js
+++ b/lib/eventbrite/controllers/auth/get/validation.js
@@ -1,0 +1,6 @@
+const Joi = require('joi');
+console.log('VALIDATION');
+
+module.exports = () => ({
+  code: Joi.string().required(),
+});

--- a/lib/eventbrite/controllers/auth/get/validation.js
+++ b/lib/eventbrite/controllers/auth/get/validation.js
@@ -1,6 +1,10 @@
 const Joi = require('joi');
 console.log('VALIDATION');
 
+// module.exports = () => ({
+//   code: Joi.string().required(),
+// });
+
 module.exports = () => ({
   code: Joi.string().required(),
 });

--- a/lib/eventbrite/controllers/auth/index.js
+++ b/lib/eventbrite/controllers/auth/index.js
@@ -34,7 +34,7 @@ module.exports = function auth() {
         cb: app.bind(this)(),
       },
       getOrganisations: {
-        // validation: organisationsVal(definition),
+        validation: organisationsVal(definition),
         cb: organisations.bind(this)(),
       },
     },

--- a/lib/eventbrite/controllers/auth/index.js
+++ b/lib/eventbrite/controllers/auth/index.js
@@ -4,6 +4,8 @@ const deauthorize = require('./deauthorize');
 const deauthorizeVal = require('./deauthorize/validation');
 const app = require('./app');
 const appVal = require('./app/validation');
+const organisations = require('./get');
+const organisationsVal = require('./get/validation');
 
 module.exports = function auth() {
   const seneca = this;
@@ -13,7 +15,6 @@ module.exports = function auth() {
   seneca.context.TRANSPARENT = false;
 
   const definition = {};
-
   return {
     name,
     plugin,
@@ -31,6 +32,10 @@ module.exports = function auth() {
       getApp: {
         validation: appVal(definition),
         cb: app.bind(this)(),
+      },
+      getOrganisations: {
+        // validation: organisationsVal(definition),
+        cb: organisations.bind(this)(),
       },
     },
   };

--- a/lib/eventbrite/entities/webhook/create/index.js
+++ b/lib/eventbrite/entities/webhook/create/index.js
@@ -3,9 +3,11 @@ const request = require('request');
 module.exports = function create() {
   const ctx = this.context;
   return (args, cb) => {
+    console.log('ARGS', args)
     request.post(
       {
         url: `${ctx.API_BASE}/webhooks/`,
+        // url: `${ctx.API_BASE}/organizations/801521497943/webhooks/`,
         json: {
           endpoint_url: args.endpoint_url,
           actions: args.actions,
@@ -16,6 +18,8 @@ module.exports = function create() {
         },
       },
       (err, res, body) => {
+        console.log('BODY', body)
+        console.log('ERR', err)
         if (err) return cb(err);
         if (res.statusCode === 200) {
           cb(null, body);

--- a/lib/eventbrite/entities/webhook/create/index.js
+++ b/lib/eventbrite/entities/webhook/create/index.js
@@ -3,11 +3,9 @@ const request = require('request');
 module.exports = function create() {
   const ctx = this.context;
   return (args, cb) => {
-    console.log('ARGS', args)
     request.post(
       {
-        url: `${ctx.API_BASE}/webhooks/`,
-        // url: `${ctx.API_BASE}/organizations/801521497943/webhooks/`,
+        url: `${ctx.API_BASE}/organizations/${args.orgId}/webhooks/`,
         json: {
           endpoint_url: args.endpoint_url,
           actions: args.actions,
@@ -18,8 +16,6 @@ module.exports = function create() {
         },
       },
       (err, res, body) => {
-        console.log('BODY', body)
-        console.log('ERR', err)
         if (err) return cb(err);
         if (res.statusCode === 200) {
           cb(null, body);

--- a/lib/eventbrite/entities/webhook/get/index.js
+++ b/lib/eventbrite/entities/webhook/get/index.js
@@ -1,20 +1,19 @@
 const request = require('request');
 
 module.exports = () => (args, cb) => {
-  console.log('TOKEN', args.token)
   request
     .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${args.token}`)
     .on('response', (res) => {
       if (res.statusCode === 200) {
         res.on('data', (chunk) => {
           const body = JSON.parse(chunk);
-          console.log(body);
+          cb(null, body);
         });
       } else {
         cb('Invalid payload while authenticating to Eventbrite');
       }
     })
     .on('error', (err) => {
-      console.log(err);
+      cb(err);
     });
 };

--- a/lib/eventbrite/entities/webhook/get/index.js
+++ b/lib/eventbrite/entities/webhook/get/index.js
@@ -1,0 +1,20 @@
+const request = require('request');
+
+module.exports = () => (args, cb) => {
+  console.log('TOKEN', args.token)
+  request
+    .get(`https://www.eventbriteapi.com/v3/users/me/organizations/?token=${args.token}`)
+    .on('response', (res) => {
+      if (res.statusCode === 200) {
+        res.on('data', (chunk) => {
+          const body = JSON.parse(chunk);
+          console.log(body);
+        });
+      } else {
+        cb('Invalid payload while authenticating to Eventbrite');
+      }
+    })
+    .on('error', (err) => {
+      console.log(err);
+    });
+};

--- a/lib/eventbrite/entities/webhook/get/perm.js
+++ b/lib/eventbrite/entities/webhook/get/perm.js
@@ -1,0 +1,5 @@
+module.exports = {
+  get: [{
+    role: 'basic-user',
+  }],
+};

--- a/lib/eventbrite/entities/webhook/get/validation.js
+++ b/lib/eventbrite/entities/webhook/get/validation.js
@@ -1,0 +1,3 @@
+module.exports = definition => ({
+  token: definition.token.required(),
+});

--- a/lib/eventbrite/entities/webhook/index.js
+++ b/lib/eventbrite/entities/webhook/index.js
@@ -3,6 +3,8 @@ const createVal = require('./create/validation');
 const create = require('./create');
 const delVal = require('./delete/validation');
 const del = require('./delete');
+const get = require('./get');
+const getVal = require('./get/validation');
 
 module.exports = function webhook() {
   const seneca = this;
@@ -32,6 +34,10 @@ module.exports = function webhook() {
         validation: delVal(definition),
         cb: del.bind(this)(),
       },
+      get: {
+        validation: getVal(definition),
+        cb: get.bind(this)()
+      }
     },
   };
 };


### PR DESCRIPTION
- Helps close https://github.com/CoderDojo/cp-eventbrite-service/issues/34
- Updates the create webhook
- Edits the `auth/authorize` to no longer get the access token and passes the organisation ID through to the create webhook
- Adds `auth/get` to deal with getting the access token and also getting list of user's organisations
- Returns a list of user's organisations for the `cp-zen-platform` to handle

**To test locally**
- Checkout branch `webhook-update-organization` on `cp-zen-platform`
- Update `hostname` or `endpointUrl` so eventbrite can ping back